### PR TITLE
Add `getLumberjackPagesForGridfield` to `ArticlesPage`

### DIFF
--- a/src/Pages/ArticlesPage.php
+++ b/src/Pages/ArticlesPage.php
@@ -338,10 +338,14 @@ class ArticlesPage extends \Page
         parent::onAfterPublish();
     }
 
-    public function getLumberjackPagesForGridfield(): DataList
+    /**
+     * @var array<string> $excluded
+     */
+    public function getLumberjackPagesForGridfield(array $excluded = []): DataList
     {
         return ArticlePage::get()->filter([
             'ParentID' => $this->ID,
+            'ClassName' => $excluded,
         ]);
     }
 }

--- a/src/Pages/ArticlesPage.php
+++ b/src/Pages/ArticlesPage.php
@@ -337,4 +337,11 @@ class ArticlesPage extends \Page
 
         parent::onAfterPublish();
     }
+
+    public function getLumberjackPagesForGridfield(): DataList
+    {
+        return ArticlePage::get()->filter([
+            'ParentID' => $this->ID,
+        ]);
+    }
 }


### PR DESCRIPTION
In silverstripe/silverstripe-lumberjack#125 the behavior of various methods on the Lumberjack extension changed causing an infinite loop when a page using the lumberjack extension doesn't explicitly define the extension methods.

Work around this issue by explicitly defining `getLumberjackPagesForGridfield` on the Article page.