### PR TITLE
Revert lumberjack workaround

### DIFF
--- a/src/Pages/ArticlesPage.php
+++ b/src/Pages/ArticlesPage.php
@@ -312,11 +312,4 @@ class ArticlesPage extends \Page
 
         parent::onAfterPublish();
     }
-
-    public function getLumberjackPagesForGridfield(): DataList
-    {
-        return ArticlePage::get()->filter([
-            'ParentID' => $this->ID,
-        ]);
-    }
 }

--- a/src/Pages/ArticlesPage.php
+++ b/src/Pages/ArticlesPage.php
@@ -313,14 +313,10 @@ class ArticlesPage extends \Page
         parent::onAfterPublish();
     }
 
-    /**
-     * @var array<string> $excluded
-     */
-    public function getLumberjackPagesForGridfield(array $excluded = []): DataList
+    public function getLumberjackPagesForGridfield(): DataList
     {
         return ArticlePage::get()->filter([
             'ParentID' => $this->ID,
-            'ClassName' => $excluded,
         ]);
     }
 }


### PR DESCRIPTION
In #34 we introduced a workaround for the lumberjack issue silverstripe/silverstripe-lumberjack#125 so we could deploy the latest update of this module without breaking. In the meantime there have been new stable releases for lumberjack that fix the bug so there isn't a need anymore to ship the workaround in our module and since we're relying on the default lumberjack behavior its better to not override the method with a copy of the default behavior at some random point in time.